### PR TITLE
Use env var for secrets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ login-sandbox:
 	fly -t sandbox login  --concourse-url http://192.168.100.4:8080/
 
 pipeline-check: ${CONCOURSE_SECRETS_FILE}
-	# Explicitly call bash here to get process substitution
+	# Explicitly call bash here to get process substitution, otherwise make
+	# runs the shell in a mode that doesn't support <(...)
 	yes | bash -c "fly -t ${TARGET} set-pipeline -c fissile-stemcell-openSUSE-check.yml -p fissile-stemcell-openSUSE-check -l <(gpg --decrypt --batch --no-tty ${CONCOURSE_SECRETS_FILE})"
 	fly -t ${TARGET} unpause-pipeline -p fissile-stemcell-openSUSE-check

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ login-sandbox:
 	fly -t sandbox login  --concourse-url http://192.168.100.4:8080/
 
 pipeline-check:
-	gpg --decrypt --batch --no-tty ${CONCOURSE_SECRETS_FILE} > ${TMP_SECRETS_FILE}
+	gpg --decrypt --batch --no-tty ${CONCOURSE_SECRETS_FILE} > ${TMP_SECRETS_FILE} 2> /dev/null
 	yes | fly -t ${TARGET} set-pipeline -c fissile-stemcell-openSUSE-check.yml -p fissile-stemcell-openSUSE-check -l ${TMP_SECRETS_FILE}
 	fly -t ${TARGET} unpause-pipeline -p fissile-stemcell-openSUSE-check
 	rm -f ${TMP_SECRETS_FILE}

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ CONCOURSE_URL ?= https://ci.from-the.cloud/
 GITHUB_ID ?= c29a4757ff0e43c25610
 GITHUB_TEAM ?= 'SUSE/Team Alfred'
 CONCOURSE_SECRETS_FILE ?= ../cloudfoundry/secure/concourse-secrets.yml.gpg
-TMP_SECRETS_FILE := $(shell mktemp -t tmp-concourseXXXXXX)
 
 all: pipeline-check
 
@@ -13,8 +12,7 @@ login-vancouver:
 login-sandbox:
 	fly -t sandbox login  --concourse-url http://192.168.100.4:8080/
 
-pipeline-check:
-	gpg --decrypt --batch --no-tty ${CONCOURSE_SECRETS_FILE} > ${TMP_SECRETS_FILE} 2> /dev/null
-	yes | fly -t ${TARGET} set-pipeline -c fissile-stemcell-openSUSE-check.yml -p fissile-stemcell-openSUSE-check -l ${TMP_SECRETS_FILE}
+pipeline-check: ${CONCOURSE_SECRETS_FILE}
+	# Explicitly call bash here to get process substitution
+	yes | bash -c "fly -t ${TARGET} set-pipeline -c fissile-stemcell-openSUSE-check.yml -p fissile-stemcell-openSUSE-check -l <(gpg --decrypt --batch --no-tty ${CONCOURSE_SECRETS_FILE})"
 	fly -t ${TARGET} unpause-pipeline -p fissile-stemcell-openSUSE-check
-	rm -f ${TMP_SECRETS_FILE}

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ TARGET ?= skycastle
 CONCOURSE_URL ?= https://ci.from-the.cloud/
 GITHUB_ID ?= c29a4757ff0e43c25610
 GITHUB_TEAM ?= 'SUSE/Team Alfred'
+CONCOURSE_SECRETS_FILE ?= ../cloudfoundry/secure/concourse-secrets.yml.gpg
+TMP_SECRETS_FILE := $(shell mktemp -t tmp-concourseXXXXXX)
 
 all: pipeline-check
 
@@ -12,6 +14,7 @@ login-sandbox:
 	fly -t sandbox login  --concourse-url http://192.168.100.4:8080/
 
 pipeline-check:
-	yes | fly -t ${TARGET} set-pipeline -c fissile-stemcell-openSUSE-check.yml -p fissile-stemcell-openSUSE-check -l ../cloudfoundry/secure/concourse-secrets.yml
+	gpg --decrypt --batch --no-tty ${CONCOURSE_SECRETS_FILE} > ${TMP_SECRETS_FILE}
+	yes | fly -t ${TARGET} set-pipeline -c fissile-stemcell-openSUSE-check.yml -p fissile-stemcell-openSUSE-check -l ${TMP_SECRETS_FILE}
 	fly -t ${TARGET} unpause-pipeline -p fissile-stemcell-openSUSE-check
-
+	rm -f ${TMP_SECRETS_FILE}


### PR DESCRIPTION
We're standardizing the secrets location across all of the pipelines. This means the `pipeline-check` target will prompt for a password now.